### PR TITLE
Add editable waypoints, camera preview

### DIFF
--- a/src/web-app/app.js
+++ b/src/web-app/app.js
@@ -4,10 +4,54 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 
 let geoLayer = null;
+let geojsonData = null;
+
+async function startCameraPreview() {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const video = document.getElementById('cameraPreview');
+    if (video) video.srcObject = stream;
+  } catch (err) {
+    console.error('Camera preview failed', err);
+  }
+}
+
+startCameraPreview();
 
 function updateFeatureCoordinates(feature, latlng) {
   if (feature.geometry.type === 'Point') {
     feature.geometry.coordinates = [latlng.lng, latlng.lat];
+  }
+}
+
+function openEditPopup(marker, feature) {
+  const props = feature.properties || {};
+  feature.properties = props;
+  const container = L.DomUtil.create('div');
+  container.innerHTML = `
+    <div>Name: <input type="text" class="prop-name" value="${props.name || ''}"></div>
+    <div>Description: <input type="text" class="prop-desc" value="${props.description || ''}"></div>
+    <div>Tilt: <input type="number" class="prop-tilt" value="${props.cameraTilt || 0}"></div>
+    <div>Pan: <input type="number" class="prop-pan" value="${props.cameraPan || 0}"></div>
+    <button class="save-props">Save</button>
+  `;
+  marker.bindPopup(container).openPopup();
+  container.querySelector('.save-props').addEventListener('click', () => {
+    props.name = container.querySelector('.prop-name').value;
+    props.description = container.querySelector('.prop-desc').value;
+    props.cameraTilt = parseFloat(container.querySelector('.prop-tilt').value || '0');
+    props.cameraPan = parseFloat(container.querySelector('.prop-pan').value || '0');
+    marker.closePopup();
+  });
+}
+
+function setupFeatureLayer(feature, layer) {
+  if (layer instanceof L.Marker) {
+    layer.options.draggable = true;
+    layer.on('dragend', (ev) => {
+      updateFeatureCoordinates(feature, ev.target.getLatLng());
+    });
+    layer.on('click', () => openEditPopup(layer, feature));
   }
 }
 
@@ -27,28 +71,41 @@ document.getElementById('fileInput').addEventListener('change', async (e) => {
   }
   const parser = new DOMParser();
   const dom = parser.parseFromString(text, 'text/xml');
-  const geojson = toGeoJSON.kml(dom);
+  geojsonData = toGeoJSON.kml(dom);
   if (geoLayer) geoLayer.remove();
-  geoLayer = L.geoJSON(geojson, {
-    onEachFeature: (feature, layer) => {
-      if (layer instanceof L.Marker) {
-        layer.options.draggable = true;
-        layer.on('dragend', (ev) => {
-          updateFeatureCoordinates(feature, ev.target.getLatLng());
-        });
-      }
-    }
+  geoLayer = L.geoJSON(geojsonData, {
+    onEachFeature: setupFeatureLayer
   }).addTo(map);
   map.fitBounds(geoLayer.getBounds());
 });
 
+map.on('contextmenu', (e) => {
+  if (!geoLayer) {
+    geojsonData = { type: 'FeatureCollection', features: [] };
+    geoLayer = L.geoJSON(geojsonData, { onEachFeature: setupFeatureLayer }).addTo(map);
+  }
+  const feature = {
+    type: 'Feature',
+    properties: {},
+    geometry: { type: 'Point', coordinates: [e.latlng.lng, e.latlng.lat] }
+  };
+  geojsonData.features.push(feature);
+  const marker = L.marker(e.latlng, { draggable: true }).addTo(geoLayer);
+  marker.on('dragend', (ev) => {
+    updateFeatureCoordinates(feature, ev.target.getLatLng());
+  });
+  marker.on('click', () => openEditPopup(marker, feature));
+});
+
 document.getElementById('exportBtn').addEventListener('click', () => {
   if (!geoLayer) return;
-  const angle = parseFloat(document.getElementById('cameraAngle').value || '0');
+  const tilt = parseFloat(document.getElementById('cameraTilt').value || '0');
+  const pan = parseFloat(document.getElementById('cameraPan').value || '0');
   const features = geoLayer.toGeoJSON();
   features.features.forEach((f) => {
     f.properties = f.properties || {};
-    f.properties.cameraAngle = angle;
+    if (f.properties.cameraTilt === undefined) f.properties.cameraTilt = tilt;
+    if (f.properties.cameraPan === undefined) f.properties.cameraPan = pan;
   });
   const kml = tokml(features);
   const blob = new Blob([kml], {type: 'application/vnd.google-earth.kml+xml'});

--- a/src/web-app/index.html
+++ b/src/web-app/index.html
@@ -13,9 +13,15 @@
 
     <input type="file" id="fileInput" accept=".kml,.kmz">
     <div id="map"></div>
-    <label for="cameraAngle">Camera Angle
-      <input type="number" id="cameraAngle" value="0">
-    </label>
+    <div class="camera-controls">
+      <label for="cameraTilt">Camera Tilt
+        <input type="number" id="cameraTilt" value="0">
+      </label>
+      <label for="cameraPan">Camera Pan
+        <input type="number" id="cameraPan" value="0">
+      </label>
+    </div>
+    <video id="cameraPreview" autoplay playsinline></video>
     <button id="exportBtn">Export Edited KML</button>
   </div>
 

--- a/src/web-app/styles.css
+++ b/src/web-app/styles.css
@@ -26,4 +26,17 @@ input, button {
   padding: 10px;
   margin: 5px 0;
 }
+
+.camera-controls {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+#cameraPreview {
+  width: 100%;
+  height: 200px;
+  background: #000;
+  margin: 10px 0;
+}
   


### PR DESCRIPTION
## Summary
- allow tilt/pan camera settings and preview the webcam
- support editing waypoint properties in a popup
- enable adding new waypoints with right-click
- keep markers draggable

## Testing
- `npm test` *(fails: Missing script)*
- `python3 backend.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854abed760c8331b427600cbcbb8b4a