### PR TITLE
Add waypoint editing with context menu

### DIFF
--- a/src/web-app/app.js
+++ b/src/web-app/app.js
@@ -4,6 +4,22 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 
 let geoLayer = null;
+let currentGeoJSON = null;
+let contextMarker = null;
+let contextLatLng = null;
+
+function attachMarkerEvents(layer, feature) {
+  if (!(layer instanceof L.Marker)) return;
+  layer.options.draggable = true;
+  layer.on('dragend', (ev) => {
+    updateFeatureCoordinates(feature, ev.target.getLatLng());
+  });
+  layer.on('contextmenu', (e) => {
+    contextMarker = layer;
+    contextLatLng = e.latlng;
+    showContextMenu(e.containerPoint, false);
+  });
+}
 
 function updateFeatureCoordinates(feature, latlng) {
   if (feature.geometry.type === 'Point') {
@@ -28,27 +44,24 @@ document.getElementById('fileInput').addEventListener('change', async (e) => {
   const parser = new DOMParser();
   const dom = parser.parseFromString(text, 'text/xml');
   const geojson = toGeoJSON.kml(dom);
+  currentGeoJSON = geojson;
   if (geoLayer) geoLayer.remove();
-  geoLayer = L.geoJSON(geojson, {
-    onEachFeature: (feature, layer) => {
-      if (layer instanceof L.Marker) {
-        layer.options.draggable = true;
-        layer.on('dragend', (ev) => {
-          updateFeatureCoordinates(feature, ev.target.getLatLng());
-        });
-      }
-    }
-  }).addTo(map);
+  geoLayer = L.geoJSON(geojson).addTo(map);
+  geoLayer.eachLayer((layer) => {
+    attachMarkerEvents(layer, layer.feature);
+  });
   map.fitBounds(geoLayer.getBounds());
 });
 
 document.getElementById('exportBtn').addEventListener('click', () => {
   if (!geoLayer) return;
-  const angle = parseFloat(document.getElementById('cameraAngle').value || '0');
+  const tilt = parseFloat(document.getElementById('cameraTilt').value || '0');
+  const pan = parseFloat(document.getElementById('cameraPan').value || '0');
   const features = geoLayer.toGeoJSON();
   features.features.forEach((f) => {
     f.properties = f.properties || {};
-    f.properties.cameraAngle = angle;
+    if (f.properties.cameraTilt === undefined) f.properties.cameraTilt = tilt;
+    if (f.properties.cameraPan === undefined) f.properties.cameraPan = pan;
   });
   const kml = tokml(features);
   const blob = new Blob([kml], {type: 'application/vnd.google-earth.kml+xml'});
@@ -58,4 +71,91 @@ document.getElementById('exportBtn').addEventListener('click', () => {
   a.download = 'edited.kml';
   a.click();
   URL.revokeObjectURL(url);
+});
+
+function showContextMenu(point, addOnly) {
+  const menu = document.getElementById('contextMenu');
+  menu.style.left = point.x + 'px';
+  menu.style.top = point.y + 'px';
+  menu.style.display = 'block';
+  menu.dataset.addOnly = addOnly ? '1' : '0';
+  Array.from(menu.querySelectorAll('li')).forEach((li) => {
+    if (li.dataset.action === 'add') {
+      li.style.display = addOnly ? 'block' : 'none';
+    } else {
+      li.style.display = addOnly ? 'none' : 'block';
+    }
+  });
+}
+
+function hideContextMenu() {
+  document.getElementById('contextMenu').style.display = 'none';
+}
+
+map.on('contextmenu', (e) => {
+  contextMarker = null;
+  contextLatLng = e.latlng;
+  showContextMenu(e.containerPoint, true);
+});
+
+map.on('click', hideContextMenu);
+
+document.getElementById('contextMenu').addEventListener('click', (e) => {
+  const action = e.target.dataset.action;
+  hideContextMenu();
+  if (!action) return;
+  if (action === 'add') {
+    const feature = {
+      type: 'Feature',
+      properties: {},
+      geometry: { type: 'Point', coordinates: [contextLatLng.lng, contextLatLng.lat] }
+    };
+    currentGeoJSON.features.push(feature);
+    const marker = L.marker(contextLatLng).addTo(geoLayer);
+    attachMarkerEvents(marker, feature);
+    openEditDialog(feature);
+  } else if (action === 'remove' && contextMarker) {
+    geoLayer.removeLayer(contextMarker);
+    currentGeoJSON.features = currentGeoJSON.features.filter(f => f !== contextMarker.feature);
+  } else if (action === 'edit' && contextMarker) {
+    openEditDialog(contextMarker.feature);
+  }
+});
+
+function openEditDialog(feature) {
+  const dialog = document.getElementById('editDialog');
+  const fields = document.getElementById('editFields');
+  fields.innerHTML = '';
+  feature.properties = feature.properties || {};
+  if (feature.properties.cameraTilt === undefined) feature.properties.cameraTilt = 0;
+  if (feature.properties.cameraPan === undefined) feature.properties.cameraPan = 0;
+  Object.keys(feature.properties).forEach(key => {
+    const div = document.createElement('div');
+    const label = document.createElement('label');
+    label.textContent = key;
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = feature.properties[key];
+    input.dataset.key = key;
+    div.appendChild(label);
+    div.appendChild(input);
+    fields.appendChild(div);
+  });
+  dialog.currentFeature = feature;
+  dialog.style.display = 'flex';
+}
+
+document.getElementById('cancelEdit').addEventListener('click', () => {
+  document.getElementById('editDialog').style.display = 'none';
+});
+
+document.getElementById('editForm').addEventListener('submit', (e) => {
+  e.preventDefault();
+  const dialog = document.getElementById('editDialog');
+  const feature = dialog.currentFeature;
+  const inputs = dialog.querySelectorAll('input[data-key]');
+  inputs.forEach(inp => {
+    feature.properties[inp.dataset.key] = inp.value;
+  });
+  dialog.style.display = 'none';
 });

--- a/src/web-app/index.html
+++ b/src/web-app/index.html
@@ -13,10 +13,30 @@
 
     <input type="file" id="fileInput" accept=".kml,.kmz">
     <div id="map"></div>
-    <label for="cameraAngle">Camera Angle
-      <input type="number" id="cameraAngle" value="0">
+    <label for="cameraTilt">Camera Tilt
+      <input type="number" id="cameraTilt" value="0">
+    </label>
+    <label for="cameraPan">Camera Pan
+      <input type="number" id="cameraPan" value="0">
     </label>
     <button id="exportBtn">Export Edited KML</button>
+  </div>
+
+  <ul id="contextMenu" class="context-menu" style="display:none">
+    <li data-action="add">Add Waypoint</li>
+    <li data-action="remove">Remove Waypoint</li>
+    <li data-action="edit">Edit</li>
+  </ul>
+
+  <div id="editDialog" class="modal" style="display:none">
+    <div class="modal-content">
+      <h3>Edit Waypoint</h3>
+      <form id="editForm">
+        <div id="editFields"></div>
+        <button type="submit">Save</button>
+        <button type="button" id="cancelEdit">Cancel</button>
+      </form>
+    </div>
   </div>
 
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>

--- a/src/web-app/styles.css
+++ b/src/web-app/styles.css
@@ -26,4 +26,42 @@ input, button {
   padding: 10px;
   margin: 5px 0;
 }
+
+.context-menu {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  list-style: none;
+  padding: 5px 0;
+  margin: 0;
+  z-index: 1000;
+}
+
+.context-menu li {
+  padding: 5px 20px;
+  cursor: pointer;
+}
+
+.context-menu li:hover {
+  background: #f0f0f0;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1001;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  width: 300px;
+}
   


### PR DESCRIPTION
## Summary
- add context menu to right click on map/markers
- allow adding, removing and editing waypoint properties
- support camera tilt and pan values
- style context menu and modal dialog

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854b0b6f5b083318de2e35d2891890e